### PR TITLE
Change mobifyjs-utils dependancy to download with git:// link

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "main": "resizeImages.js",
     "dependencies": {
-        "mobifyjs-utils": "git@github.com:mobify/mobifyjs-utils.git#1.0.0"
+        "mobifyjs-utils": "git://github.com/mobify/mobifyjs-utils.git#1.0.0"
     },
     "devDependencies": {
         "requirejs": "2.1.10",


### PR DESCRIPTION
Status: **Opened for visibility**

Reviewers: *\* @MikeKlemarewski @kbingman **
Linked PRs: *\* https://github.com/mobify/generator-adaptivejs/pull/68 **
## Changes
- Changes mobifyjs-utils dep to use git:// url
## Why are we doing this?
- Removes the need for Windows users to authenticate with github via ssh keys
## How to test-drive this PR
- Have git setup so that it doesn't know how to authenticate to github via ssh keys
- bower install
- Did things install properly?
