### PR TITLE
Bump version and add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+tests/
+node_modules/
+.gitignore
+.git
+Gruntfile.js
+bower.json
+circle.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "imageresize-client",
-    "version": "1.0.1",
+    "version": "1.0.5",
     "devDependencies": {
         "grunt": "~0.4.0",
         "grunt-express": "~0.3.6",


### PR DESCRIPTION
## Changes
- Update version to latest tagged version
- Add .npmignore
## How to test-drive this PR
- Request access to publish the npm module from Mike K
- run `npm publish`
- Make sure only the package.json, README.md, and resizeimages.js file get pushed to npm.
